### PR TITLE
Update README and patch fixed column calling in conversion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Since all the reporting is done in a very simple and quite naive Python implemen
 # Requirements
 - pandas
 - XlsxWriter
+- babel
+- python>3.9
 
 # Testing
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Since all the reporting is done in a very simple and quite naive Python implemen
 
 # Requirements
 - pandas
+- openpyxl
 - XlsxWriter
 - babel
 - python>3.9


### PR DESCRIPTION
- The conversion script from swaab adds dependencies (babel -> python>3.9)
- The conversion script for schwaab uses fixed column locations, but column locations may vary in export --> quick patch by creating a mapping file between expected column location and actual column location