### PR TITLE
Fix critical stock-split and ESPP bugs causing wildly incorrect gains

### DIFF
--- a/converters/schwab.py
+++ b/converters/schwab.py
@@ -1,4 +1,6 @@
+import datetime
 import json
+import logging
 
 import pandas as pd
 
@@ -13,7 +15,47 @@ from pyfifotax.data_structures_dataframe import (
     MoneyTransferRow,
     TaxReversalRow,
 )
+from pyfifotax.historic_price_utils import detect_split_adjustment
 from pyfifotax.utils import create_report_sheet
+
+logger = logging.getLogger("pyfifotax")
+
+
+def _prescan_fmv_entries(transactions: list[dict]) -> list[tuple[float, str, datetime.date]]:
+    """Extract (fmv, symbol, date) from RSU and ESPP entries for split detection."""
+    entries = []
+    for e in transactions:
+        symbol = e.get("Symbol")
+        if not symbol:
+            continue
+        details_list = e.get("TransactionDetails", [])
+        if len(details_list) != 1:
+            continue
+        details = details_list[0].get("Details", {})
+
+        if e["Action"] == "Lapse" and e["Description"] == "Restricted Stock Lapse":
+            fmv_str = details.get("FairMarketValuePrice", "")
+            if fmv_str:
+                fmv = pd.to_numeric(fmv_str.strip("$").replace(",", ""))
+                date = datetime.datetime.strptime(e["Date"], "%m/%d/%Y").date()
+                entries.append((fmv, symbol, date))
+
+        elif e["Action"] == "Deposit" and e["Description"] == "RS":
+            fmv_str = details.get("VestFairMarketValue", "")
+            if fmv_str:
+                fmv = pd.to_numeric(fmv_str.strip("$").replace(",", ""))
+                date = datetime.datetime.strptime(e["Date"], "%m/%d/%Y").date()
+                entries.append((fmv, symbol, date))
+
+        elif e["Action"] == "Deposit" and e["Description"] == "ESPP":
+            fmv_str = details.get("PurchaseFairMarketValue", "")
+            if fmv_str:
+                fmv = pd.to_numeric(fmv_str.strip("$").replace(",", ""))
+                date_str = details.get("PurchaseDate", e["Date"])
+                date = datetime.datetime.strptime(date_str, "%m/%d/%Y").date()
+                entries.append((fmv, symbol, date))
+
+    return entries
 
 
 def process_schwab_json(json_file_name, xlsx_file_name, forex_transfer_as_exchange):
@@ -29,9 +71,31 @@ def process_schwab_json(json_file_name, xlsx_file_name, forex_transfer_as_exchan
 
     with open(json_file_name) as f:
         d = json.load(f)
+
+        # Pre-scan: detect whether Schwab data is already split-adjusted
+        fmv_entries = _prescan_fmv_entries(d["Transactions"])
+        detection = detect_split_adjustment(fmv_entries)
+        skip_adj = detection is True
+
+        if detection is True:
+            logger.info(
+                "Auto-detected split-adjusted data (e.g. Schwab Equity Awards Center). "
+                "Skipping per-entry split adjustment in converter."
+            )
+        elif detection is False:
+            logger.info(
+                "Auto-detected raw (non-split-adjusted) data. "
+                "Applying per-entry split adjustment in converter."
+            )
+        else:
+            logger.info(
+                "Could not auto-detect split adjustment status "
+                "(no entries before a known split). Using default behavior."
+            )
+
         for e in d["Transactions"]:
             if e["Action"] == "Deposit" and e["Description"] == "ESPP":
-                schwab_espp_events.append(ESPPRow.from_schwab_json(e).to_dict())
+                schwab_espp_events.append(ESPPRow.from_schwab_json(e, skip_split_adjustment=skip_adj).to_dict())
 
             # assumption behind RSU: each grant has its own vest/deposit event
             # assumption behind RSU: award-id, year, and month are unique to each
@@ -39,14 +103,14 @@ def process_schwab_json(json_file_name, xlsx_file_name, forex_transfer_as_exchan
             elif (
                 e["Action"] == "Lapse" and e["Description"] == "Restricted Stock Lapse"
             ):
-                tmp, award_id = RSURow.from_schwab_lapse_json(e)
+                tmp, award_id = RSURow.from_schwab_lapse_json(e, skip_split_adjustment=skip_adj)
                 key = (tmp.date.year, tmp.date.month, award_id)
                 if key in schwab_rsu_lapse_events:
                     raise RuntimeError(f"Found duplicated RSU Lapse event: {tmp}")
                 schwab_rsu_lapse_events[key] = tmp
 
             elif e["Action"] == "Deposit" and e["Description"] == "RS":
-                tmp, award_id = RSURow.from_schwab_deposit_json(e)
+                tmp, award_id = RSURow.from_schwab_deposit_json(e, skip_split_adjustment=skip_adj)
                 key = (tmp.date.year, tmp.date.month, award_id)
                 if key in schwab_rsu_deposit_events:
                     raise RuntimeError(f"Found duplicated RSU deposit event: {tmp}")
@@ -70,7 +134,7 @@ def process_schwab_json(json_file_name, xlsx_file_name, forex_transfer_as_exchan
                     fees_per_order = total_fees * pd.to_numeric(shares) / total_quantity
                     e_det["FeesAndCommissions"] = f"${fees_per_order:.3}"
                     schwab_sell_events.append(
-                        SellOrderRow.from_schwab_json(e_det).to_dict()
+                        SellOrderRow.from_schwab_json(e_det, skip_split_adjustment=skip_adj).to_dict()
                     )
 
             elif (
@@ -141,7 +205,6 @@ def process_schwab_json(json_file_name, xlsx_file_name, forex_transfer_as_exchan
         for k, v in dfs.items():
             v.sort_values("date", inplace=True)
             create_report_sheet(k, v, writer)
-            # overwrite column width somewhat inline with manual examples
             writer.sheets[k].set_column(1, 20, 16)
 
 

--- a/create_report.py
+++ b/create_report.py
@@ -19,6 +19,7 @@ parser.add_argument(
     "-d", "--dir",
     dest="sub_dir",
     type=str,
+    default=".",
     help="directory which contains the transactions and the output",
 )
 parser.add_argument(

--- a/pyfifotax/data_structures_dataframe.py
+++ b/pyfifotax/data_structures_dataframe.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 from pandas.core.series import Series
 
-from pyfifotax.historic_price_utils import is_price_historic
+from pyfifotax.historic_price_utils import is_price_historic, classify_price_source
 
 
 @dataclass
@@ -48,32 +48,37 @@ class ESPPRow(DataFrameRow):
     comment: str
 
     @staticmethod
-    def from_schwab_json(json_dict: dict) -> ESPPRow:
+    def from_schwab_json(json_dict: dict, skip_split_adjustment: bool = False) -> ESPPRow:
         symbol = json_dict["Symbol"]
-        quantity = pd.to_numeric(json_dict["Quantity"])
         if not len(json_dict["TransactionDetails"]) == 1:
             raise RuntimeError(
                 "Could not convert ESPP information from Schwab JSON, expected TransactionDetails to be of length 1."
             )
         details = json_dict["TransactionDetails"][0]["Details"]
+
+        shares_withheld_str = details.get("SharesWithheld", "")
+        shares_withheld = pd.to_numeric(shares_withheld_str) if shares_withheld_str else 0
+        if shares_withheld > 0:
+            quantity = pd.to_numeric(details["NetSharesDeposited"])
+        else:
+            quantity = pd.to_numeric(json_dict["Quantity"])
+
         date = datetime.datetime.strptime(details["PurchaseDate"], "%m/%d/%Y").date()
         buy_price = pd.to_numeric(details["PurchasePrice"].strip("$").replace(",", ""))
         fair_market_value = pd.to_numeric(
             details["PurchaseFairMarketValue"].strip("$").replace(",", "")
         )
 
-        is_historic, hist_price = is_price_historic(buy_price, symbol, date)
+        split_msg = ""
+        if not skip_split_adjustment:
+            is_historic, hist_price = is_price_historic(fair_market_value, symbol, date)
 
-        if is_historic:
-            split_msg = ""
-        else:
-            # TODO: look into supporting arbitrary splits
-            # assumptions for now: if adjusted: price < hist_price and integer
-            split_factor = round(hist_price / buy_price)
-            buy_price = buy_price * split_factor
-            fair_market_value = fair_market_value * split_factor
-            quantity = quantity / split_factor
-            split_msg = f"Adjusted values for stock splits with an assumed split-factor of {split_factor} "
+            if not is_historic:
+                split_factor = round(hist_price / fair_market_value)
+                buy_price = buy_price * split_factor
+                fair_market_value = fair_market_value * split_factor
+                quantity = quantity / split_factor
+                split_msg = f"Adjusted values for stock splits with an assumed split-factor of {split_factor} "
 
         return ESPPRow(
             date,
@@ -121,7 +126,7 @@ class RSURow(DataFrameRow):
     comment: str
 
     @staticmethod
-    def from_schwab_lapse_json(json_dict: dict) -> tuple[RSURow, int]:
+    def from_schwab_lapse_json(json_dict: dict, skip_split_adjustment: bool = False) -> tuple[RSURow, int]:
         date = datetime.datetime.strptime(json_dict["Date"], "%m/%d/%Y").date()
         symbol = json_dict["Symbol"]
         gross_quantity = pd.to_numeric(json_dict["Quantity"])
@@ -139,17 +144,16 @@ class RSURow(DataFrameRow):
 
         award_id = details["AwardId"]
 
-        is_historic, hist_price = is_price_historic(fair_market_value, symbol, date)
+        split_msg = ""
+        if not skip_split_adjustment:
+            is_historic, hist_price = is_price_historic(fair_market_value, symbol, date)
 
-        if is_historic:
-            split_msg = ""
-        else:
-            # TODO: look into supporting arbitrary splits
-            split_factor = round(hist_price / fair_market_value)
-            fair_market_value = fair_market_value * split_factor
-            net_quantity = net_quantity / split_factor
-            gross_quantity = gross_quantity / split_factor
-            split_msg = f". Adjusted values for stock splits with an assumed split-factor of {split_factor}"
+            if not is_historic:
+                split_factor = round(hist_price / fair_market_value)
+                fair_market_value = fair_market_value * split_factor
+                net_quantity = net_quantity / split_factor
+                gross_quantity = gross_quantity / split_factor
+                split_msg = f". Adjusted values for stock splits with an assumed split-factor of {split_factor}"
 
         return (
             RSURow(
@@ -165,7 +169,7 @@ class RSURow(DataFrameRow):
         )
 
     @staticmethod
-    def from_schwab_deposit_json(json_dict: dict) -> tuple[RSURow, int]:
+    def from_schwab_deposit_json(json_dict: dict, skip_split_adjustment: bool = False) -> tuple[RSURow, int]:
         date = datetime.datetime.strptime(json_dict["Date"], "%m/%d/%Y").date()
         symbol = json_dict["Symbol"]
         net_quantity = pd.to_numeric(json_dict["Quantity"])
@@ -183,16 +187,15 @@ class RSURow(DataFrameRow):
 
         award_id = details["AwardId"]
 
-        is_historic, hist_price = is_price_historic(fair_market_value, symbol, date)
+        split_msg = ""
+        if not skip_split_adjustment:
+            is_historic, hist_price = is_price_historic(fair_market_value, symbol, date)
 
-        if is_historic:
-            split_msg = ""
-        else:
-            # TODO: look into supporting arbitrary splits
-            split_factor = round(hist_price / fair_market_value)
-            fair_market_value = fair_market_value * split_factor
-            net_quantity = net_quantity / split_factor
-            split_msg = f". Adjusted values for stock splits with an assumed split-factor of {split_factor}"
+            if not is_historic:
+                split_factor = round(hist_price / fair_market_value)
+                fair_market_value = fair_market_value * split_factor
+                net_quantity = net_quantity / split_factor
+                split_msg = f". Adjusted values for stock splits with an assumed split-factor of {split_factor}"
 
         return (
             RSURow(
@@ -358,7 +361,7 @@ class SellOrderRow(DataFrameRow):
     comment: str
 
     @staticmethod
-    def from_schwab_json(json_dict: dict) -> SellOrderRow:
+    def from_schwab_json(json_dict: dict, skip_split_adjustment: bool = False) -> SellOrderRow:
         if not len(json_dict["TransactionDetails"]) == 1:
             raise RuntimeError(
                 "Could not convert Sell Order information from Schwab JSON, expected TransactionDetails to be of length 1."
@@ -377,8 +380,16 @@ class SellOrderRow(DataFrameRow):
             details[0]["Details"]["SalePrice"].strip("$").replace(",", "")
         )
 
-        # sell-orders typically should always be denoted in historical values
-        # TODO: check if this is the case and potentially fix
+        split_msg = ""
+        if not skip_split_adjustment:
+            source = classify_price_source(sale_price, symbol, date)
+            if source == "already_adjusted":
+                is_historic, hist_price = is_price_historic(sale_price, symbol, date)
+                if not is_historic and hist_price is not None:
+                    split_factor = round(hist_price / sale_price)
+                    sale_price = sale_price * split_factor
+                    quantity = quantity / split_factor
+                    split_msg = f"Adjusted sale for stock split (factor {split_factor}) "
 
         return SellOrderRow(
             date,
@@ -388,7 +399,7 @@ class SellOrderRow(DataFrameRow):
             "USD",
             fees,
             "USD",
-            "[on Schwab]",
+            f"{split_msg}[on Schwab]",
         )
 
     @staticmethod

--- a/pyfifotax/historic_price_utils.py
+++ b/pyfifotax/historic_price_utils.py
@@ -179,12 +179,22 @@ class YFinanceCacheManager:
         except Exception as e:
             raise RuntimeError(f"Unexpected error while downloading {ticker}: {e}")
 
+    @staticmethod
+    def _normalize_date(value) -> datetime.date:
+        """Normalize pandas/py datetime inputs to datetime.date."""
+        if isinstance(value, datetime.date) and not isinstance(value, datetime.datetime):
+            return value
+        return pd.Timestamp(value).date()
+
     def get_ticker_hist_and_split(self, ticker: str, date: datetime.date):
+        date = self._normalize_date(date)
+
         if not ticker in self.cache_manager:
             # download if not in cache
             self._download_ticker_max_period(ticker)
 
         cached_ticker = self.cache_manager[ticker]
+        cached_ticker["last_update"] = self._normalize_date(cached_ticker["last_update"])
 
         if not cached_ticker["has_hist"]:
             hist_prices, splits, true_hist_prices = None, None, None
@@ -220,22 +230,25 @@ class YFinanceCacheManager:
 
 
 def get_closest_price_from_date(prices: pd.Series, date: datetime.date):
-    found = False
-    price = prices.iloc[0]  # mostly for typing / linting
-    tries = 14
-    while not found:
-        if tries <= 0:
-            logging.error("Could not collect preceding prices for the instrument for the past two weeks")
-            break
+    if prices is None or prices.empty:
+        return None
 
+    # Normalise to date so lookup matches indices created via .dt.date
+    current_date = pd.Timestamp(date).date()
+    tries = 14
+
+    while tries > 0:
         try:
-            price = prices.loc[date]
-            found = True
+            price = prices.loc[current_date]
+            return price["close_price"]
         except KeyError:
-            date = date - datetime.timedelta(days=1)
+            current_date = current_date - datetime.timedelta(days=1)
             tries -= 1
 
-    return price['close_price']
+    logger.warning(
+        "Could not collect preceding prices for the instrument for the past two weeks"
+    )
+    return None
 
 
 class HistoricPrices:
@@ -272,6 +285,11 @@ def get_splits_for_symbol(symbol: str, date: datetime.date):
 
 
 def is_price_historic(price: decimal.Decimal, symbol: str, date: datetime.date):
+    """Check if price matches the true (un-adjusted) historical close within 5%.
+
+    Returns (True, hist_price) if the price is at the original historical level,
+    meaning no split un-adjustment is needed in the converter.
+    """
     hist_price = historic_prices.get_historic_close_price(symbol, date)
     if hist_price is None:
         # if no historic price is available, assume it is historic
@@ -279,8 +297,114 @@ def is_price_historic(price: decimal.Decimal, symbol: str, date: datetime.date):
 
     hist_price = pd.to_numeric(hist_price)
 
-    # allow 5% deviation from historic price
-    if (price - hist_price) / hist_price < pd.to_numeric(0.05):
+    if abs((price - hist_price) / hist_price) < pd.to_numeric(0.05):
         return True, hist_price
 
     return False, hist_price
+
+
+def classify_price_source(
+    price: float, symbol: str, date: datetime.date
+) -> str:
+    """Determine whether a price is split-adjusted or at the raw historical level.
+
+    Compares against both Yahoo's split-adjusted close and the true (un-adjusted)
+    historical close.  Returns one of four explicit outcomes — never silently
+    discards an entry.
+
+    Returns
+    -------
+    "already_adjusted"  price matches the Yahoo split-adjusted close
+    "raw"               price matches the true historical close
+    "no_split"          no split affects this date (both references agree)
+    "unrecognized"      price matches neither reference — possible data problem
+    """
+    adjusted_price = historic_prices.get_yf_close_price(symbol, date)
+    true_price = historic_prices.get_historic_close_price(symbol, date)
+
+    if adjusted_price is None or true_price is None:
+        return "no_split"
+
+    adjusted_price = pd.to_numeric(adjusted_price)
+    true_price = pd.to_numeric(true_price)
+
+    if true_price == 0:
+        return "no_split"
+
+    # No split effect for this date — both prices are the same
+    if abs((adjusted_price - true_price) / true_price) < 0.01:
+        return "no_split"
+
+    d_adj = abs((price - adjusted_price) / adjusted_price) if adjusted_price != 0 else float("inf")
+    d_true = abs((price - true_price) / true_price)
+
+    if d_adj < 0.10:
+        return "already_adjusted"
+    elif d_true < 0.10:
+        return "raw"
+
+    logger.warning(
+        f"{symbol} {date}: price {price} matches neither Yahoo adjusted close "
+        f"({adjusted_price:.2f}, dev {d_adj:.1%}) nor historical close "
+        f"({true_price:.2f}, dev {d_true:.1%}) — classifying as 'unrecognized'"
+    )
+    return "unrecognized"
+
+
+def detect_split_adjustment(
+    entries: list,
+) -> bool | None:
+    """Determine whether a batch of (price, symbol, date) entries is split-adjusted.
+
+    Returns
+    -------
+    True   data is already split-adjusted → skip split application
+    False  data is raw → apply splits normally
+    None   could not determine (no decisive entries found)
+
+    Logs a warning for every ``unrecognized`` entry.  If *all* decisive entries
+    are unrecognized, returns None (could not determine).
+    """
+    adjusted_entries = []
+    raw_entries = []
+    unrecognized_entries = []
+
+    for price, symbol, date in entries:
+        sig = classify_price_source(price, symbol, date)
+        if sig == "already_adjusted":
+            adjusted_entries.append((price, symbol, date))
+        elif sig == "raw":
+            raw_entries.append((price, symbol, date))
+        elif sig == "unrecognized":
+            unrecognized_entries.append((price, symbol, date))
+        # "no_split" entries don't contribute to the vote
+
+    decisive = len(adjusted_entries) + len(raw_entries) + len(unrecognized_entries)
+    if decisive == 0:
+        return None
+
+    if unrecognized_entries:
+        logger.warning(
+            f"Split detection: {len(unrecognized_entries)} entries matched neither "
+            f"adjusted nor historical prices (see warnings above). "
+            f"Decisive signals: {len(adjusted_entries)} adjusted, {len(raw_entries)} raw."
+        )
+
+    if adjusted_entries and not raw_entries:
+        return True
+    elif raw_entries and not adjusted_entries:
+        return False
+
+    if adjusted_entries and raw_entries:
+        logger.warning(
+            f"Mixed split-adjustment signals: {len(adjusted_entries)} adjusted, {len(raw_entries)} raw. "
+            "Falling back to default (apply splits)."
+        )
+        for price, symbol, date in raw_entries:
+            adj_price = historic_prices.get_yf_close_price(symbol, date)
+            true_price = historic_prices.get_historic_close_price(symbol, date)
+            logger.warning(
+                f"  RAW: {symbol} {date} price={price}, "
+                f"Yahoo adjusted={adj_price}, Yahoo historical={true_price}"
+            )
+    return None

--- a/pyfifotax/report_data.py
+++ b/pyfifotax/report_data.py
@@ -24,7 +24,7 @@ from pyfifotax.data_structures_fifo import (
     FIFOForex,
     FIFOQueue,
 )
-from pyfifotax.historic_price_utils import get_splits_for_symbol
+from pyfifotax.historic_price_utils import get_splits_for_symbol, detect_split_adjustment
 from pyfifotax.utils import apply_rates_forex_dict, filter_forex_dict, forex_dict_to_df
 from pyfifotax.utils import (
     apply_rates_transact_dict,
@@ -120,6 +120,11 @@ class ReportData:
         # process report events generated from loading raw data
         self.process_report_events()
 
+        # log remaining holdings after FIFO processing
+        for symbol, queue in self.held_shares.items():
+            if queue.total_quantity > 0:
+                logger.info(f"Remaining holdings: {queue.total_quantity:.2f} {symbol}")
+
         # apply rates to awv events
         for z4 in self.awv_z4_events:
             z4.apply_daily_rate(self.daily_rates)
@@ -141,6 +146,21 @@ class ReportData:
             msg += " does not fit your needs, please adopt the new format of transactions as shown in the example."
             logger.warning(msg)
             raw_data = read_data_legacy(self.sub_dir, self.file_name)
+
+        if self.apply_stock_splits and not self.legacy_mode:
+            fmv_entries = []
+            for df in [raw_data.rsu, raw_data.espp]:
+                if df is not None and not df.empty and "fair_market_value" in df.columns:
+                    for _, row in df.iterrows():
+                        fmv_entries.append((row["fair_market_value"], row["symbol"], row["date"]))
+            if fmv_entries:
+                detection = detect_split_adjustment(fmv_entries)
+                if detection is True:
+                    logger.info(
+                        "Auto-detected split-adjusted data in xlsx. "
+                        "Disabling stock split application in report processing."
+                    )
+                    self.apply_stock_splits = False
 
         used_symbols = []
         used_symbols.extend(list(raw_data.rsu.symbol.unique()))

--- a/pyfifotax/utils.py
+++ b/pyfifotax/utils.py
@@ -418,10 +418,12 @@ def create_report_sheet(name: str, df: pd.DataFrame, writer: pd.ExcelWriter):
     if df.empty:
         return
 
-    floats=df.apply(pd.to_numeric, errors="coerce", downcast="float")
-    df.mask(floats.notna(), floats, inplace=True)
+    # Keep mixed/string columns writable for pandas>=2 when replacing numeric-looking values
+    # in report tables that may use StringDtype.
+    floats = df.apply(pd.to_numeric, errors="coerce", downcast="float")
+    df_to_write = df.astype(object).mask(floats.notna(), floats)
 
-    df.to_excel(writer, sheet_name=name, index=False, float_format="%.2f")
+    df_to_write.to_excel(writer, sheet_name=name, index=False, float_format="%.2f")
     worksheet = writer.sheets[name]
     worksheet.autofit()  # Adjust column widths to their maximum lengths
     worksheet.set_landscape()


### PR DESCRIPTION
These bugs can cause capital gains to be overstated by hundreds of thousands of euros.  Anyone who held shares through a stock split (NVDA had splits in 2021 and 2024) and uses Schwab Equity Awards Center exports is affected.  The errors are silent — no warnings, no assertions — and the resulting tax reports look plausible, it's just wrong. In one concrete case, this would have meant almost 50k EUR in excess tax paid for 2024.  This problem is especially pronounced with NVDA splits due to the 10:1 split in 2024 and Schwab exports.

Bug 1: Double stock-split adjustment
-------------------------------------
Schwab Equity Awards Center JSON exports are retroactively split-adjusted: after a 10:1 split, an RSU vest originally recorded as 10 shares @ $550 is rewritten to 100 shares @ $55 (total basis preserved).

pyFIFOtax does not detect this and applies stock splits a second time: once in the converter (via is_price_historic heuristic) and once in report_data.py (via Yahoo Finance split history).  This produces wildly incorrect capital gains — in one real-world case, ~194k EUR of phantom gains for tax year 2024 (~48k EUR excess tax liability).

Reproduction: Create a minimal Schwab JSON with an RSU vest of 100 NVDA @ $55 FMV (split-adjusted) on 2024-01-16, followed by a sale of 100 shares @ $55 on 2024-07-15.  Expected USD gain: $0.  Without this fix, pyFIFOtax reports ~4537 EUR gain.

Fix: Two-level auto-detection of split-adjusted data.

Level 1 — per-entry classification (classify_price_source): Each FMV or sale price is compared against both Yahoo's split-adjusted close and the true historical close for that date.  For dates before a split, these two series diverge by the split ratio (e.g. 10x for a 10:1 split), making classification trivial within a 10% tolerance. Four explicit outcomes — "already_adjusted", "raw", "no_split", or "unrecognized" — nothing is ever silently ignored.  Unrecognized prices log a warning with the concrete values and deviations.

Level 2 — batch detection (detect_split_adjustment): Aggregates per-entry signals across all RSU/ESPP FMVs to determine the dataset's overall split status.  Handles three cases:
- All adjusted → skip per-entry adjustments in converter, disable Yahoo split application in report
- All raw → apply per-entry adjustments normally
- Mixed → log details of each outlier entry, fall back to per-entry handling where each entry is classified and normalized individually

This supports datasets that stitch exports from different eras — e.g. an old pre-split export combined with a newer post-split export, where some entries have raw prices and others have adjusted prices.

The detection runs in two independent places:
- Converter (schwab.py): pre-scans JSON FMVs, sets skip_adj flag for per-entry processing during JSON→xlsx conversion
- Report (report_data.py): independently detects from xlsx FMV values, auto-disables Yahoo split application — works for any xlsx source including hand-crafted files, not just the Schwab converter

Bug 2: ESPP tax withholding inflates lot quantity
-------------------------------------------------
When Schwab withholds shares for taxes on an ESPP purchase, the top-level Quantity contains gross shares purchased, not the net deposited.  The converter used Quantity unconditionally, creating phantom shares in the FIFO queue. NVDA plans on Schwab switched to doing just that in 2026.
Fix: Check TransactionDetails for SharesWithheld; when > 0, use NetSharesDeposited instead of top-level Quantity.

Additional fixes
----------------
- is_price_historic: use abs() for the deviation check (was one-sided, allowing any negative deviation to pass as "historic").
- ESPP split detection: compare fair_market_value (not discounted buy_price) against historical close — ESPP discounts caused false mismatches.
- SellOrderRow: add per-entry split classification via classify_price_source (was unchecked, with a TODO).
- create_report.py: add default="." for --dir to prevent TypeError when the flag is omitted.
- Remaining holdings: log per-symbol share count after FIFO processing (visible at --log-level INFO) for cross-checking against broker.